### PR TITLE
to support ioredis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,26 @@
 
 Fastify Redis connection plugin, with this you can share the same Redis connection in every part of your server.
 
-Under the hood the official [redis](https://github.com/NodeRedis/node_redis) client is used, the options that you pass to `register` will be passed to the Redis client.
+Under the hood the official [redis](https://github.com/NodeRedis/node_redis) client is used, the ``options`` that you pass to `register` which the ``redis`` option will be passed to the Redis client.
 
 ## Install
 ```
 npm i fastify-redis --save
 ```
 ## Usage
-Add it to you project with `register` and you are done!  
+Add it to you project with `register` and you are done!
 You can access the *Redis* client via `fastify.redis`.
+
+And you can custom your own redis client, use ``driver`` option, now only support [ioredis](https://github.com/luin/ioredis) client, default is [redis](https://github.com/NodeRedis/node_redis).
+
 ```js
 const fastify = require('fastify')
 
 fastify.register(require('fastify-redis'), {
-  host: '127.0.0.1'
+  driver: require('ioredis'), // when you custom your redis client. optional
+  redis: {
+    host: '127.0.0.1'
+  }
 }, err => {
   if (err) throw err
 })

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Fastify Redis connection plugin, with this you can share the same Redis connection in every part of your server.
 
-Under the hood the official [redis](https://github.com/NodeRedis/node_redis) client is used, the ``options`` that you pass to `register` which the ``redis`` option will be passed to the Redis client.
+Under the hood the official [redis](https://github.com/NodeRedis/node_redis) client is used, the ``options`` that you pass to `register` will be passed to the Redis client.
 
 ## Install
 ```
@@ -14,16 +14,14 @@ npm i fastify-redis --save
 Add it to you project with `register` and you are done!
 You can access the *Redis* client via `fastify.redis`.
 
-And you can custom your own redis client, use ``driver`` option, now only support [ioredis](https://github.com/luin/ioredis) client, default is [redis](https://github.com/NodeRedis/node_redis).
+And you can custom your own redis client, use ``driver`` option, now support [ioredis](https://github.com/luin/ioredis) client, default is [redis](https://github.com/NodeRedis/node_redis).
 
 ```js
 const fastify = require('fastify')
 
 fastify.register(require('fastify-redis'), {
   driver: require('ioredis'), // when you custom your redis client. optional
-  redis: {
-    host: '127.0.0.1'
-  }
+  host: '127.0.0.1'
 }, err => {
   if (err) throw err
 })

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ npm i fastify-redis --save
 Add it to you project with `register` and you are done!
 You can access the *Redis* client via `fastify.redis`.
 
-And you can custom your own redis client, use ``driver`` option, now support [ioredis](https://github.com/luin/ioredis) client, default is [redis](https://github.com/NodeRedis/node_redis).
+If needed, you can pass a custom ``driver`` option, such as [ioredis](https://github.com/luin/ioredis). By default the official [redis](https://github.com/NodeRedis/node_redis) client is used.
+
 
 ```js
 const fastify = require('fastify')
 
 fastify.register(require('fastify-redis'), {
-  driver: require('ioredis'), // when you custom your redis client. optional
+  driver: require('ioredis'),
   host: '127.0.0.1'
 }, err => {
   if (err) throw err

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ const redis = require('redis')
 
 function fastifyRedis (fastify, options, next) {
   var client = null
-
   try {
-    client = redis.createClient(options)
+    // if custom redis module, default is redis.
+    var Redis = options.driver
+    client = Redis ? new Redis(options.redis) : redis.createClient(options.redis)
   } catch (err) {
     return next(err)
   }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ function fastifyRedis (fastify, options, next) {
   var client = null
   try {
     // if custom redis module, default is redis.
-    var Redis = options.driver
-    client = Redis ? new Redis(options.redis) : redis.createClient(options.redis)
+    const Driver = options.driver
+    delete options.driver
+    client = Driver ? new Driver(options) : redis.createClient(options)
   } catch (err) {
     return next(err)
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
     "fastify": "^0.30.2",
+    "ioredis": "^3.2.1",
     "standard": "^10.0.3",
     "tap": "^10.7.2"
   },

--- a/test.js
+++ b/test.js
@@ -9,9 +9,7 @@ t.beforeEach(done => {
   const fastify = Fastify()
 
   fastify.register(fastifyRedis, {
-    redis: {
-      host: '127.0.0.1'
-    }
+    host: '127.0.0.1'
   }, (err) => {
     t.error(err)
   })
@@ -30,9 +28,7 @@ test('fastify.redis should exist', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.register(fastifyRedis, {
-    redis: {
-      host: '127.0.0.1'
-    }
+    host: '127.0.0.1'
   }, (err) => {
     t.error(err)
   })
@@ -50,9 +46,7 @@ test('fastify.redis should be the redis client', t => {
   const fastify = Fastify()
 
   fastify.register(fastifyRedis, {
-    redis: {
-      host: '127.0.0.1'
-    }
+    host: '127.0.0.1'
   }, (err) => {
     t.error(err)
   })
@@ -78,9 +72,7 @@ test('fastify.redis should exist when use the custom redis driver', t => {
 
   fastify.register(fastifyRedis, {
     driver: require('ioredis'),
-    redis: {
-      host: '127.0.0.1'
-    }
+    host: '127.0.0.1'
   }, (err) => {
     t.error(err)
   })
@@ -99,9 +91,7 @@ test('fastify.redis should be the redis client when use the custom redis driver'
 
   fastify.register(fastifyRedis, {
     driver: require('ioredis'),
-    redis: {
-      host: '127.0.0.1'
-    }
+    host: '127.0.0.1'
   }, (err) => {
     t.error(err)
   })

--- a/test.js
+++ b/test.js
@@ -9,7 +9,9 @@ t.beforeEach(done => {
   const fastify = Fastify()
 
   fastify.register(fastifyRedis, {
-    host: '127.0.0.1'
+    redis: {
+      host: '127.0.0.1'
+    }
   }, (err) => {
     t.error(err)
   })
@@ -27,9 +29,10 @@ t.beforeEach(done => {
 test('fastify.redis should exist', t => {
   t.plan(3)
   const fastify = Fastify()
-
   fastify.register(fastifyRedis, {
-    host: '127.0.0.1'
+    redis: {
+      host: '127.0.0.1'
+    }
   }, (err) => {
     t.error(err)
   })
@@ -47,7 +50,58 @@ test('fastify.redis should be the redis client', t => {
   const fastify = Fastify()
 
   fastify.register(fastifyRedis, {
-    host: '127.0.0.1'
+    redis: {
+      host: '127.0.0.1'
+    }
+  }, (err) => {
+    t.error(err)
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.redis.set('key', 'value', err => {
+      t.error(err)
+      fastify.redis.get('key', (err, val) => {
+        t.error(err)
+        t.equal(val, 'value')
+
+        fastify.close()
+      })
+    })
+  })
+})
+
+test('fastify.redis should exist when use the custom redis driver', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  fastify.register(fastifyRedis, {
+    driver: require('ioredis'),
+    redis: {
+      host: '127.0.0.1'
+    }
+  }, (err) => {
+    t.error(err)
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+    t.ok(fastify.redis)
+
+    fastify.close()
+  })
+})
+
+test('fastify.redis should be the redis client when use the custom redis driver', t => {
+  t.plan(5)
+  const fastify = Fastify()
+
+  fastify.register(fastifyRedis, {
+    driver: require('ioredis'),
+    redis: {
+      host: '127.0.0.1'
+    }
   }, (err) => {
     t.error(err)
   })


### PR DESCRIPTION
Adjust the `options` that pass to the `register`,  the `driver` option to support [ioredis](https://github.com/luin/ioredis), and the `redis` option will be passed to the Redis client.