### PR TITLE
do not quit given client on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fastify.listen(3000, err => {
 
 You may also supply an existing *Redis* client instance by passing an options
 object with the `client` property set to the instance. In this case,
-the client is not automatically close when the Fastify instance is
+the client is not automatically closed when the Fastify instance is
 closed.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ npm i fastify-redis --save
 ```
 ## Usage
 Add it to your project with `register` and you are done!
-You can access the *Redis* client via `fastify.redis`.
+You can access the *Redis* client via `fastify.redis`. The client is
+automatically closed when the fastify instance is closed.
 
 ```js
 const fastify = require('fastify')
@@ -40,7 +41,9 @@ fastify.listen(3000, err => {
 ```
 
 You may also supply an existing *Redis* client instance by passing an options
-object with the `client` property set to the instance.
+object with the `client` property set to the instance. In this case,
+the client is not automatically close when the Fastify instance is
+closed.
 
 ```js
 const fastify = Fastify()

--- a/index.js
+++ b/index.js
@@ -12,11 +12,10 @@ function fastifyRedis (fastify, options, next) {
     } catch (err) {
       return next(err)
     }
+    fastify.addHook('onClose', close)
   }
 
-  fastify
-    .decorate('redis', client)
-    .addHook('onClose', close)
+  fastify.decorate('redis', client)
 
   next()
 }

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ test('promises support', t => {
 })
 
 test('custom client', t => {
-  t.plan(5)
+  t.plan(7)
   const fastify = Fastify()
   const redis = require('redis').createClient({ host: 'localhost', port: 6379 })
 
@@ -100,7 +100,12 @@ test('custom client', t => {
         t.error(err)
         t.equal(val, 'value')
 
-        fastify.close()
+        fastify.close(function (err) {
+          t.error(err)
+          fastify.redis.quit(function (err) {
+            t.error(err)
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
This PR aligns the behavior of fastify-redis with the others database driver. If a client is passed in, then it will not be closed. This speeds up tests significantly because we won’t have to recreate that many connections.