### PR TITLE
Add node 12 to CI and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "12"
   - "10"
   - "8"
   - "6"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^1.5.0",
-    "ioredis": "^4.9.0",
-    "redis": "^2.8.0"
+    "ioredis": "^4.9.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
     "fastify-plugin": "^1.5.0",
     "ioredis": "^4.9.0",
     "redis": "^2.8.0"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "tap"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
     "fastify": "^2.3.0",
+    "redis": "^2.8.0",
     "standard": "^12.0.1",
     "tap": "^12.6.6"
   },

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
-    "fastify": "^2.0.0",
-    "standard": "^12.0.0",
-    "tap": "^12.0.1"
+    "fastify": "^2.3.0",
+    "standard": "^12.0.1",
+    "tap": "^12.6.6"
   },
   "dependencies": {
-    "fastify-plugin": "^1.2.0",
-    "ioredis": "^4.0.0",
+    "fastify-plugin": "^1.5.0",
+    "ioredis": "^4.9.0",
     "redis": "^2.8.0"
   }
 }


### PR DESCRIPTION
Updates the dependencies to their latest available version, except for tap.

NB: Node 6 has gone EOL since yesterday, so we should remove Node 6 from the CI config and update tap to it's latest version (currently 13.1.1 -> apart from dropping Node 6 support it won't break the package and all the tests are passing without any problem).