### PR TITLE
Add redis streams compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ fastify.listen(3000, function (err) {
   }
 })
 ```
+*NB: you will find more information about Redis streams and the relevant commands [here](https://redis.io/topics/streams-intro) and [here](https://redis.io/commands#stream).*
 
 ## Acknowledgements
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function fastifyRedis (fastify, options, next) {
     fastify.redis[namespace] = client
   } else {
     if (fastify.redis) {
-      return next(new Error('fastify-redis has already been registered'))
+      next(new Error('fastify-redis has already been registered'))
     } else {
       if (!client) {
         try {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function fastifyRedis (fastify, options, next) {
     fastify.redis[namespace] = client
   } else {
     if (fastify.redis) {
-      next(new Error('fastify-redis has already been registered'))
+      return next(new Error('fastify-redis has already been registered'))
     } else {
       if (!client) {
         try {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
-    "fastify": "^2.3.0",
+    "fastify": "^2.4.1",
     "redis": "^2.8.0",
     "standard": "^12.0.1",
-    "tap": "^12.6.6"
+    "tap": "^12.7.0"
   },
   "dependencies": {
-    "fastify-plugin": "^1.5.0",
-    "ioredis": "^4.9.0"
+    "fastify-plugin": "^1.6.0",
+    "ioredis": "^4.10.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
-    "fastify": "^2.4.1",
+    "fastify": "^2.5.0",
     "redis": "^2.8.0",
     "standard": "^12.0.1",
     "tap": "^12.7.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && tap test.js",
-    "redis": "docker run -p 6379:6379 --rm redis:3.0.7"
+    "redis": "docker run -p 6379:6379 --rm redis:latest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && tap test.js",
-    "redis": "docker run -p 6379:6379 --rm redis:latest"
+    "redis": "docker run -p 6379:6379 --rm redis:5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Close https://github.com/fastify/fastify-redis/issues/31
- Use `ioredis@4.10.0` (allow to use Redis streams commands)
- Bump dependencies

#### Checklist

- [x] run `npm run test`
- [ ] tests are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)