### PR TITLE
Fix existing redis client example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ closed.
 const fastify = require('fastify')()
 const redis = require('redis').createClient({ host: 'localhost', port: 6379 })
 
-fastify.register(fastifyRedis, { client: redis })
+fastify.register(require('fastify-redis'), { client: redis })
 
 // ...
 // ...


### PR DESCRIPTION
The existing redis client example pass a non-declared variable to the register function. I think my change is in line with other examples, but feel free to fix how you see fit. Thank you!

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
