### PR TITLE
fix: add missing namespace and closeClient type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,16 @@ declare module 'fastify' {
   }
 }
 
-export type FastifyRedisPlugin = RedisOptions & { url?: string } | { client: Redis }
+export type FastifyRedisPlugin = RedisOptions &
+{
+  url?: string;
+  namespace?: string;
+} |
+{
+  client: Redis;
+  namespace?: string;
+  closeClient?: boolean;
+}
 
 declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPlugin>;
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -6,7 +6,7 @@ const app = Fastify();
 const redis = new IORedis({ host: 'localhost', port: 6379 });
 
 app.register(fastifyRedis, { host: '127.0.0.1' });
-app.register(fastifyRedis, { client: redis });
+app.register(fastifyRedis, { client: redis, namespace: 'hello', closeClient: true });
 app.register(fastifyRedis, { url: 'redis://127.0.0.1:6379', keepAlive: 0 });
 
 app.get('/foo', (req: FastifyRequest, reply) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hello 👋, I noticed the fields `namespace` and `closeClient` were missing from the types definition. 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
