### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,18 @@ function fastifyRedis (fastify, options, next) {
   }
 
   if (!redisOptions.lazyConnect) {
+    const onError = function (err) {
+      client.quit(() => next(err))
+    }
+
+    const onReady = function () {
+      client.off('error', onError)
+      next()
+    }
+
     return client
-      .on('ready', next)
-      .on('error', (err) => {
-        client.quit(() => next(err))
-      })
+      .on('ready', onReady)
+      .on('error', onError)
   }
 
   next()

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function fastifyRedis (fastify, options, next) {
       // Any other errors during startup will
       // trigger the 'end' event.
       if (err instanceof Redis.ReplyError) {
-        this.emit('end', err)
+        onEnd(err)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -65,12 +65,14 @@ function fastifyRedis (fastify, options, next) {
   }
 
   if (!redisOptions.lazyConnect) {
-    return client.info((err, _) => {
-      return err ? next(err) : next()
-    })
-  } else {
-    next()
+    return client
+      .on('ready', next)
+      .on('error', (err) => {
+        client.quit(() => next(err))
+      })
   }
+
+  next()
 }
 
 function close (fastify, done) {

--- a/index.js
+++ b/index.js
@@ -74,9 +74,11 @@ function fastifyRedis (fastify, options, next) {
       next()
     }
 
-    return client
+    client
       .on('ready', onReady)
       .on('error', onError)
+
+    return
   }
 
   next()

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ test('fastify.redis should support url', (t) => {
 
         return this
       }
-      this.off = () => {}
+      this.off = function () { return this }
 
       return this
     }

--- a/test/test.js
+++ b/test/test.js
@@ -74,6 +74,13 @@ test('fastify.redis should support url', (t) => {
       })
       this.quit = () => {}
       this.info = cb => cb(null, 'info')
+      this.on = function (name, handler) {
+        if (name === 'ready') {
+          handler(null, 'ready')
+        }
+
+        return this
+      }
       return this
     }
   })
@@ -377,7 +384,7 @@ test('Should not throw within different contexts', (t) => {
 })
 
 test('Should throw when trying to connect on an invalid host', (t) => {
-  t.plan(2)
+  t.plan(1)
 
   const fastify = Fastify({ pluginTimeout: 20000 })
   t.teardown(() => fastify.close())
@@ -388,8 +395,7 @@ test('Should throw when trying to connect on an invalid host', (t) => {
     })
 
   fastify.ready((err) => {
-    t.type(err, 'MaxRetriesPerRequestError')
-    t.equal(err.message, 'Reached the max retries per request limit (which is 20). Refer to "maxRetriesPerRequest" option for details.')
+    t.ok(err)
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -81,6 +81,8 @@ test('fastify.redis should support url', (t) => {
 
         return this
       }
+      this.off = () => {}
+
       return this
     }
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description

Closes #95 

This PR improves error handling, it will make the plugin wait until `Redis` instance fires `ready` event before calling the `next` function, it will also listen to the `error` event and propagate errors in case anything goes wrong on initial startup.



