### PR TITLE
fix: types and tests coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ yarn.lock
 # editor files
 .vscode
 .idea
+
+# test tap report
+out.tap

--- a/.taprc
+++ b/.taprc
@@ -3,4 +3,4 @@ jsx: false
 flow: false
 jobs: 1
 coverage: true
-check-coverage: false
+check-coverage: true

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module 'fastify' {
   }
 }
 
-export type FastifyRedisPlugin = (RedisOptions &
+export type FastifyRedisPluginOptions = (RedisOptions &
 {
   url?: string;
   namespace?: string;
@@ -23,5 +23,10 @@ export type FastifyRedisPlugin = (RedisOptions &
   closeClient?: boolean;
 }
 
-declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPlugin>;
+/**
+ * @deprecated Use `FastifyRedisPluginOptions` instead
+ */
+export type FastifyRedisPlugin = FastifyRedisPluginOptions;
+
+declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPluginOptions>;
 export default fastifyRedis;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module 'fastify' {
   }
 }
 
-export type FastifyRedisPluginOptions = (RedisOptions &
+export type FastifyRedisPlugin = (RedisOptions &
 {
   url?: string;
   namespace?: string;
@@ -23,5 +23,5 @@ export type FastifyRedisPluginOptions = (RedisOptions &
   closeClient?: boolean;
 }
 
-declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPluginOptions>;
+declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPlugin>;
 export default fastifyRedis;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,27 @@
 import { FastifyPluginCallback } from 'fastify';
 import { Redis, RedisOptions } from 'ioredis';
 
+export interface FastifyRedisNamespacedInstance {
+  [namespace: string]: Redis;
+}
+
+export type FastifyRedis = FastifyRedisNamespacedInstance & Redis;
+
 declare module 'fastify' {
   interface FastifyInstance {
-    redis: Redis;
+    redis: FastifyRedis;
   }
 }
 
-export type FastifyRedisPlugin = RedisOptions &
+export type FastifyRedisPluginOptions = (RedisOptions &
 {
   url?: string;
   namespace?: string;
-} |
-{
+}) | {
   client: Redis;
   namespace?: string;
   closeClient?: boolean;
 }
 
-declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPlugin>;
-
+declare const fastifyRedis: FastifyPluginCallback<FastifyRedisPluginOptions>;
 export default fastifyRedis;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function fastifyRedis (fastify, options, next) {
 
   if (namespace) {
     if (!fastify.redis) {
-      fastify.decorate('redis', {})
+      fastify.decorate('redis', Object.create(null))
     }
 
     if (fastify.redis[namespace]) {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function fastifyRedis (fastify, options, next) {
 
     const onError = function (err) {
       // Swallow network errors to allow ioredis
-      // to preform reconnection and emit 'end'
+      // to perform reconnection and emit 'end'
       // event if reconnection eventually
       // fails.
       // Any other errors during startup will

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "lint": "standard",
+    "lint:fix": "standard --fix",
     "redis": "docker run -p 6379:6379 --rm redis:5",
     "test": "npm run lint && npm run unit && npm run typescript",
     "typescript": "tsd",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "redis": "docker run -p 6379:6379 --rm redis:5",
     "test": "npm run lint && npm run unit && npm run typescript",
     "typescript": "tsd",
-    "unit": "tap test/test.js"
+    "unit": "tap test/test.js",
+    "unit:report": "tap test/test.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",
+    "unit:verbose": "tap test/test.js -Rspec"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run lint && npm run unit && npm run typescript",
     "typescript": "tsd",
     "unit": "tap test/test.js",
-    "unit:report": "tap test/test.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",
+    "unit:report": "tap test/test.js --cov --coverage-report=html --coverage-report=cobertura",
     "unit:verbose": "tap test/test.js -Rspec"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
   },
   "homepage": "https://github.com/fastify/fastify-redis#readme",
   "devDependencies": {
-    "@types/ioredis": "^4.19.3",
-    "@types/node": "^16.0.0",
-    "fastify": "^3.11.0",
+    "@types/ioredis": "^4.27.4",
+    "@types/node": "^16.9.6",
+    "fastify": "^3.21.6",
     "proxyquire": "^2.1.3",
-    "redis": "^3.0.2",
-    "standard": "^16.0.0",
-    "tap": "^15.0.2",
+    "redis": "^3.1.2",
+    "standard": "^16.0.3",
+    "tap": "^15.0.10",
     "tsd": "^0.17.0"
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "ioredis": "^4.22.0"
+    "ioredis": "^4.27.9"
   },
   "tsd": {
     "directory": "test/types"

--- a/test/test.js
+++ b/test/test.js
@@ -493,7 +493,7 @@ test('Should be able to register multiple namespaced fastify-redis instances', a
     namespace: 'two'
   })
 
-  await fastify.ready().catch(err => t.error(err))
+  await fastify.ready()
   t.ok(fastify.redis)
   t.ok(fastify.redis.one)
   t.ok(fastify.redis.two)

--- a/test/test.js
+++ b/test/test.js
@@ -460,3 +460,19 @@ test('Should throw authentication error when trying to connect on a valid host w
       })
     })
 })
+
+test('Should successfully create a Redis client when registered with a `url` option and without a `client` option in a namespaced instance', async t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(fastifyRedis, {
+    url: 'redis://127.0.0.1',
+    namespace: 'test'
+  })
+
+  await fastify.ready().catch(err => t.error(err))
+  t.ok(fastify.redis)
+  t.ok(fastify.redis.test)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -476,3 +476,25 @@ test('Should successfully create a Redis client when registered with a `url` opt
   t.ok(fastify.redis)
   t.ok(fastify.redis.test)
 })
+
+test('Should be able to register multiple namespaced fastify-redis instances', async t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(fastifyRedis, {
+    url: 'redis://127.0.0.1',
+    namespace: 'one'
+  })
+
+  await fastify.register(fastifyRedis, {
+    url: 'redis://127.0.0.1',
+    namespace: 'two'
+  })
+
+  await fastify.ready().catch(err => t.error(err))
+  t.ok(fastify.redis)
+  t.ok(fastify.redis.one)
+  t.ok(fastify.redis.two)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -472,7 +472,7 @@ test('Should successfully create a Redis client when registered with a `url` opt
     namespace: 'test'
   })
 
-  await fastify.ready().catch(err => t.error(err))
+  await fastify.ready()
   t.ok(fastify.redis)
   t.ok(fastify.redis.test)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -498,3 +498,36 @@ test('Should be able to register multiple namespaced fastify-redis instances', a
   t.ok(fastify.redis.one)
   t.ok(fastify.redis.two)
 })
+
+test('Should throw when fastify-redis is initialized with an option that makes Redis throw', (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  // This will throw a `TypeError: this.options.Connector is not a constructor`
+  fastify.register(fastifyRedis, {
+    Connector: 'should_fail'
+  })
+
+  fastify.ready(err => {
+    t.ok(err)
+  })
+})
+
+test('Should throw when fastify-redis is initialized with a namespace and an option that makes Redis throw', (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  // This will throw a `TypeError: this.options.Connector is not a constructor`
+  fastify.register(fastifyRedis, {
+    Connector: 'should_fail',
+    namespace: 'fail'
+  })
+
+  fastify.ready(err => {
+    t.ok(err)
+  })
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,31 +1,36 @@
-import Fastify, { FastifyRequest } from 'fastify';
-import fastifyRedis from '../..';
-import IORedis from 'ioredis';
+import Fastify, { FastifyInstance } from 'fastify'
+import IORedis, { Redis } from 'ioredis'
+import { expectAssignable, expectError, expectType } from 'tsd'
+import fastifyRedis, { FastifyRedis, FastifyRedisNamespacedInstance } from '../..'
 
-const app = Fastify();
-const redis = new IORedis({ host: 'localhost', port: 6379 });
+const app: FastifyInstance = Fastify()
+const redis: Redis = new IORedis({ host: 'localhost', port: 6379 })
 
-app.register(fastifyRedis, { host: '127.0.0.1' });
-app.register(fastifyRedis, { client: redis, namespace: 'hello', closeClient: true });
-app.register(fastifyRedis, { url: 'redis://127.0.0.1:6379', keepAlive: 0 });
+app.register(fastifyRedis, { host: '127.0.0.1' })
 
-app.get('/foo', (req: FastifyRequest, reply) => {
-  const { redis } = app;
-  const query = req.query as {
-    key: string
-  }
-  redis.get(query.key, (err, val) => {
-    reply.send(err || val);
-  });
-});
+app.register(fastifyRedis, {
+  client: redis,
+  closeClient: true,
+  namespace: 'one'
+})
 
-app.post('/foo', (req, reply) => {
-  const { redis } = app;
-  const body = req.body as {
-    key: string,
-    value: string
-  }
-  redis.set(body.key, body.value, err => {
-    reply.send(err || { status: 'ok' });
-  });
-});
+app.register(fastifyRedis, {
+  keepAlive: 0,
+  namespace: 'two',
+  url: 'redis://127.0.0.1:6379'
+})
+
+expectError(app.register(fastifyRedis, {
+  namespace: 'three',
+  unknownOption: 'this should trigger a typescript error'
+}))
+
+// Plugin property available
+app.after(() => {
+  expectAssignable<Redis>(app.redis)
+  expectType<FastifyRedis>(app.redis)
+
+  expectAssignable<FastifyRedisNamespacedInstance>(app.redis)
+  expectType<Redis>(app.redis.one)
+  expectType<Redis>(app.redis.two)
+})


### PR DESCRIPTION
Hello,

closes issue https://github.com/fastify/fastify-redis/issues/102 and closes https://github.com/fastify/fastify-redis/pull/103 that seems to be abandoned.

- initialize `fastify.redis` decorator with `Object.create(null)`
- add test cases to improve coverage
- add namespaced instance types
- typescript namings have been changed to be more explicit (deprecate `FastifyRedisPlugin` and use `FastifyRedisPluginOptions` instead)
- add typescript tests
- add a few commands to make maintenance easier on this package
- achieve 100% coverage (closes https://github.com/fastify/fastify-redis/issues/84)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
