### PR TITLE
feat: add extra behavior of promises from ioredis passing custom prom…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ fastify.listen(3000, err => {
 })
 ```
 
+You can also add extra behavior of promises from [ioredis](https://github.com/luin/ioredis) passing a custom promise library:
+
+```js
+'use strict'
+
+const Promise = require('bluebird')
+fastify.register(require('fastify-redis'), {
+  promise: Promise
+})
+```
+
 You may also supply an existing *Redis* client instance by passing an options
 object with the `client` property set to the instance. In this case,
 the client is not automatically closed when the Fastify instance is

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ function fastifyRedis (fastify, options, next) {
   const { namespace, url, ...redisOptions } = options
 
   let client = options.client || null
+  const promise = options.promise || null
+  delete options.promise
 
   if (namespace) {
     if (!fastify.redis) {
@@ -23,6 +25,9 @@ function fastifyRedis (fastify, options, next) {
 
     if (!client) {
       try {
+        if (promise) {
+          Redis.Promise = promise
+        }
         if (url) {
           client = new Redis(url, redisOptions)
         } else {
@@ -45,6 +50,9 @@ function fastifyRedis (fastify, options, next) {
     } else {
       if (!client) {
         try {
+          if (promise) {
+            Redis.Promise = promise
+          }
           if (url) {
             client = new Redis(url, redisOptions)
           } else {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/ioredis": "^4.27.4",
     "@types/node": "^16.9.6",
+    "bluebird": "^3.7.2",
     "fastify": "^3.21.6",
     "proxyquire": "^2.1.3",
     "redis": "^3.1.2",


### PR DESCRIPTION
I'd like to add some extra behavior on ioredis promise using a external library. In this case, I've use bluebird for ilustrate what can you do.

I hope it can help.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
