### PR TITLE
docs(readme): create options, add more headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Once you have registered your plugin, you can access the Redis client via `fasti
 The client is automatically closed when the fastify instance is closed.
 
 ```js
+'use strict'
+
+const Fastify = require('fastify')
+const fastifyRedis = require('fastify-redis')
+
+const fastify = Fastify({ logger: true })
+
+fastify.register(fastifyRedis, { 
+  host: '127.0.0.1', 
+  password: 'your strong password here',
+  port: 6379, // Redis port
+  family: 4   // 4 (IPv4) or 6 (IPv6)
+})
+
 fastify.get('/foo', (req, reply) => {
   const { redis } = fastify
   redis.get(req.query.key, (err, val) => {

--- a/README.md
+++ b/README.md
@@ -7,26 +7,42 @@
 
 Fastify Redis connection plugin; with this you can share the same Redis connection in every part of your server.
 
-Under the hood [ioredis](https://github.com/luin/ioredis) is used as client, the ``options`` that you pass to `register` will be passed to the Redis client.
-
 ## Install
+
 ```
 npm i fastify-redis --save
 ```
+
 ## Usage
+
 Add it to your project with `register` and you are done!
-You can access the *Redis* client via `fastify.redis`. The client is
-automatically closed when the fastify instance is closed.
+
+### Create a new Redis Client
+
+Under the hood [ioredis](https://github.com/luin/ioredis) is used as client, the ``options`` that you pass to `register` will be passed to the Redis client.
 
 ```js
-'use strict'
-
 const fastify = require('fastify')()
 
+// minimum options
 fastify.register(require('fastify-redis'), { host: '127.0.0.1' })
-// or
-fastify.register(require('fastify-redis'), { url: 'redis://127.0.0.1', /* other redis options */ })
 
+// OR with more options
+fastify.register(require('fastify-redis'), { 
+  host: '127.0.0.1', 
+  password: '***',
+  port: 6379, // Redis port
+  family: 4   // 4 (IPv4) or 6 (IPv6)
+})
+```
+
+### Accessing the Redis Client
+
+Once you're registered your plugin, you can access the Redis client via `fastify.redis`. 
+
+The client is automatically closed when the fastify instance is closed.
+
+```js
 fastify.get('/foo', (req, reply) => {
   const { redis } = fastify
   redis.get(req.query.key, (err, val) => {
@@ -46,6 +62,8 @@ fastify.listen(3000, err => {
   console.log(`server listening on ${fastify.server.address().port}`)
 })
 ```
+
+### Using an existing Redis client
 
 You may also supply an existing *Redis* client instance by passing an options
 object with the `client` property set to the instance. In this case,

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Under the hood [ioredis](https://github.com/luin/ioredis) is used as client, the
 ```js
 const fastify = require('fastify')()
 
-// minimum options
+// create by specifying host
 fastify.register(require('fastify-redis'), { host: '127.0.0.1' })
+
+// OR or by specifying Redis URL
+fastify.register(require('fastify-redis'), { url: 'redis://127.0.0.1', /* other redis options */ })
 
 // OR with more options
 fastify.register(require('fastify-redis'), { 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const fastify = require('fastify')()
 // create by specifying host
 fastify.register(require('fastify-redis'), { host: '127.0.0.1' })
 
-// OR or by specifying Redis URL
+// OR by specifying Redis URL
 fastify.register(require('fastify-redis'), { url: 'redis://127.0.0.1', /* other redis options */ })
 
 // OR with more options
@@ -41,7 +41,7 @@ fastify.register(require('fastify-redis'), {
 
 ### Accessing the Redis Client
 
-Once you're registered your plugin, you can access the Redis client via `fastify.redis`. 
+Once you have registered your plugin, you can access the Redis client via `fastify.redis`. 
 
 The client is automatically closed when the fastify instance is closed.
 


### PR DESCRIPTION
As a developer, I want complete samples incl. minimum client configuration options, which would include the redis client password. 

I had to manually open the [ioredis](https://github.com/luin/ioredis) documentation to check if it expected a `password` or `secret` configuration option. Probably the former. But including an example here saves first time users the trouble of looking it up - thanks 🙂 🙏

### Original 

In the original, only the hostname was provided. 

```js
fastify.register(require('fastify-redis'), { host: '127.0.0.1' })
// or
fastify.register(require('fastify-redis'), { url: 'redis://127.0.0.1', /* other redis options */ })
```

Btw - why was it `host` in the first example and then `url`?

### Suggestion

Changes the 2nd example to include some common options, esp. `password`

```js
fastify.register(require('fastify-redis'), { 
  host: '127.0.0.1', 
  password: '***',
  port: 6379, // Redis port
  family: 4   // 4 (IPv4) or 6 (IPv6)
})
```



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
