### PR TITLE
Fix clientClose to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ fastify.register(require('@fastify/redis'), { client })
 Note: by default, *@fastify/redis* will **not** automatically close the client
 connection when the Fastify server shuts down.
 
+To automatically close client connections, set clientClose to true.
+
+```js
+fastify.register(require('@fastify/redis'), { client, closeClient: true })
+```
+
 ## Registering multiple Redis client instances
 
 By using the `namespace` option you can register multiple Redis client instances.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ fastify.register(require('@fastify/redis'), { client })
 Note: by default, *@fastify/redis* will **not** automatically close the client
 connection when the Fastify server shuts down.
 
-To automatically close client connections, set clientClose to true.
+To automatically close the client connection, set clientClose to true.
 
 ```js
 fastify.register(require('@fastify/redis'), { client, closeClient: true })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,9 @@ declare namespace fastifyRedis {
   }) | {
     client: Redis | Cluster;
     namespace?: string;
+    /**
+     * @default false
+     */
     closeClient?: boolean;
   }
   /*


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

When clientClose is set to true, the client connection is automatically closed when the Fastify server shuts down.

Reported in issue https://github.com/fastify/fastify-redis/issues/176

This PR was developed with respect to https://github.com/fastify/fastify-redis/pull/66





#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
