### PR TITLE
Swap ioredis for iovalkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add it to your project with `register` and you are done!
 
 ### Create a new Redis Client
 
-Under the hood [ioredis](https://github.com/luin/ioredis) is used as client, the ``options`` that you pass to `register` will be passed to the Redis client.
+Under the hood [iovalkey](https://github.com/mcollina/iovalkey) is used as client, the ``options`` that you pass to `register` will be passed to the Redis client.
 
 ```js
 const fastify = require('fastify')()
@@ -90,7 +90,7 @@ closed.
 'use strict'
 
 const fastify = require('fastify')()
-const Redis = require('ioredis')
+const Redis = require('iovalkey')
 
 const client = new Redis({ host: 'localhost', port: 6379 })
 
@@ -220,7 +220,7 @@ fastify.listen({ port: 3000 }, function (err) {
 *NB you can find more information about Redis streams and the relevant commands [here](https://redis.io/topics/streams-intro) and [here](https://redis.io/commands#stream).*
 
 ## Redis connection error
-Majority of errors are silent due to the `ioredis` silent error handling but during the plugin registration it will check that the connection with the redis instance is correctly estabilished.
+Majority of errors are silent due to the `iovalkey` silent error handling but during the plugin registration it will check that the connection with the redis instance is correctly estabilished.
 In this case you can receive an `ERR_AVVIO_PLUGIN_TIMEOUT` error if the connection can't be estabilished in the expected time frame or a dedicated error for an invalid connection.
 
 ## Acknowledgements

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const Redis = require('ioredis')
+const Redis = require('iovalkey')
 
 function fastifyRedis (fastify, options, next) {
   const { namespace, url, closeClient = false, ...redisOptions } = options
@@ -95,7 +95,7 @@ function fastifyRedis (fastify, options, next) {
       return
     }
 
-    // Swallow network errors to allow ioredis
+    // Swallow network errors to allow iovalkey
     // to perform reconnection and emit 'end'
     // event if reconnection eventually
     // fails.
@@ -106,7 +106,7 @@ function fastifyRedis (fastify, options, next) {
     }
   }
 
-  // ioredis provides it in a .status property
+  // iovalkey provides it in a .status property
   if (client.status === 'ready') {
     // client is already connected, do not register event handlers
     // call next() directly to avoid ERR_AVVIO_PLUGIN_TIMEOUT

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "database",
     "speed",
     "cache",
-    "ioredis"
+    "ioredis",
+    "iovalkey"
   ],
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
@@ -45,7 +46,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^4.0.0",
-    "ioredis": "^5.0.0"
+    "iovalkey": "^0.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ test('fastify.redis should support url', (t) => {
   const fastify = Fastify()
 
   const fastifyRedis = proxyquire('..', {
-    ioredis: function Redis (path, options) {
+    iovalkey: function Redis (path, options) {
       t.equal(path, 'redis://127.0.0.1')
       t.same(options, {
         otherOption: 'foo'
@@ -160,10 +160,10 @@ test('promises support', (t) => {
   })
 })
 
-test('custom ioredis client that is already connected', (t) => {
+test('custom iovalkey client that is already connected', (t) => {
   t.plan(10)
   const fastify = Fastify()
-  const Redis = require('ioredis')
+  const Redis = require('iovalkey')
   const redis = new Redis({ host: 'localhost', port: 6379 })
 
   // use the client now, so that it is connected and ready
@@ -201,10 +201,10 @@ test('custom ioredis client that is already connected', (t) => {
   })
 })
 
-test('custom ioredis client that is already connected', (t) => {
+test('custom iovalkey client that is already connected', (t) => {
   t.plan(10)
   const fastify = Fastify()
-  const Redis = require('ioredis')
+  const Redis = require('iovalkey')
   const redis = new Redis({ host: 'localhost', port: 6379 })
 
   // use the client now, so that it is connected and ready
@@ -245,7 +245,7 @@ test('custom ioredis client that is already connected', (t) => {
 test('If closeClient is enabled, close the client.', (t) => {
   t.plan(10)
   const fastify = Fastify()
-  const Redis = require('ioredis')
+  const Redis = require('iovalkey')
   const redis = new Redis({ host: 'localhost', port: 6379 })
 
   redis.set('key', 'value', (err) => {
@@ -288,7 +288,7 @@ test('If closeClient is enabled, close the client.', (t) => {
 test('If closeClient is enabled, close the client namespace.', (t) => {
   t.plan(10)
   const fastify = Fastify()
-  const Redis = require('ioredis')
+  const Redis = require('iovalkey')
   const redis = new Redis({ host: 'localhost', port: 6379 })
 
   redis.set('key', 'value', (err) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from 'fastify';
-import { Cluster, Redis, RedisOptions } from 'ioredis';
+import { Cluster, Redis, RedisOptions } from 'iovalkey';
 
 type FastifyRedisPluginType = FastifyPluginCallback<fastifyRedis.FastifyRedisPluginOptions>
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,11 +1,11 @@
 import Fastify, { FastifyInstance } from 'fastify'
-import IORedis, { Redis } from 'ioredis'
+import IOValKey, { Redis } from 'iovalkey'
 import { expectAssignable, expectDeprecated, expectError, expectType } from 'tsd'
 import fastifyRedis, { FastifyRedis, FastifyRedisPlugin, FastifyRedisNamespacedInstance, FastifyRedisPluginOptions } from '..'
 
 const app: FastifyInstance = Fastify()
-const redis: Redis = new IORedis({ host: 'localhost', port: 6379 })
-const redisCluster= new IORedis.Cluster([{ host: 'localhost', port: 6379 }])
+const redis: Redis = new IOValKey({ host: 'localhost', port: 6379 })
+const redisCluster= new IOValKey.Cluster([{ host: 'localhost', port: 6379 }])
 
 app.register(fastifyRedis, { host: '127.0.0.1' })
 


### PR DESCRIPTION
Swap to a default redis client with a higher chance of getting maintained. iovalkey is a friendly fork maintained by @mcollina. I'm guessing this would be a breaking/major version bump if this lands.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
