### PR TITLE
chore: migrate from tap to node test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "valkey": "docker run -p 6379:6379 --rm valkey/valkey:7.2",
     "test": "npm run unit && npm run typescript",
     "typescript": "tsd",
-    "unit": "tap",
-    "unit:report": "tap --cov --coverage-report=html --coverage-report=cobertura",
-    "unit:verbose": "tap -Rspec"
+    "unit": "node --test",
+    "unit:report": "c8 node --test",
+    "unit:verbose": "node --test --test-reporter=spec"
   },
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.4",
     "proxyquire": "^2.1.3",
     "standard": "^17.1.0",
-    "tap": "^18.7.1",
     "tsd": "^0.31.0",
     "why-is-node-running": "^2.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "valkey": "docker run -p 6379:6379 --rm valkey/valkey:7.2",
     "test": "npm run unit && npm run typescript",
     "typescript": "tsd",
-    "unit": "node --test",
+    "unit": "c8 --100 node --test",
     "unit:report": "c8 node --test",
     "unit:verbose": "node --test --test-reporter=spec"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
-    "fastify": "^5.0.0-alpha.4",
+    "fastify": "^5.0.0",
     "proxyquire": "^2.1.3",
     "standard": "^17.1.0",
     "tsd": "^0.31.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const whyIsNodeRunning = require('why-is-node-running')
-const { test, before } = require('node:test')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 const Fastify = require('fastify')
 const fastifyRedis = require('..')
 
-before(async () => {
+test.beforeEach(async () => {
   const fastify = Fastify()
 
   fastify.register(fastifyRedis, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

This PR removes tap and uses `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
