### PR TITLE
feat: detect and report self-signed certificate error in tls connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function fastifyRedis (fastify, options, next) {
     if (err.code === 'SELF_SIGNED_CERT_IN_CHAIN') {
       // This error is not recoverable because ioredis will never be able to connect to the server unless the user changes the TLS options.
       // Provide a more helpful error message to the user so they understand how to fix the issue instead of the plugin timing out.
-      const error = new Error("The server certificate does not match the host name. Consider setting the 'tls.rejectUnauthorized' option to 'false' or providing a valid certificate using the 'tls.ca' option.", { cause: err })
+      const error = new Error("Self-signed certificate detected in the certificate chain. Consider setting the 'tls.rejectUnauthorized' option to 'false' or providing a valid certificate using the 'tls.ca' option.", { cause: err })
       onEnd(error)
       return
     }

--- a/index.js
+++ b/index.js
@@ -95,9 +95,7 @@ function fastifyRedis (fastify, options, next) {
     }
     if (err.code === 'SELF_SIGNED_CERT_IN_CHAIN') {
       // This error is not recoverable because ioredis will never be able to connect to the server unless the user changes the TLS options.
-      // Provide a more helpful error message to the user so they understand how to fix the issue instead of the plugin timing out.
-      const error = new Error("Self-signed certificate detected in the certificate chain. Consider setting the 'tls.rejectUnauthorized' option to 'false' or providing a valid certificate using the 'tls.ca' option.", { cause: err })
-      onEnd(error)
+      onEnd(err)
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function close (fastify) {
 
 module.exports = fp(fastifyRedis, {
   fastify: '5.x',
-  name: '@fastify/redis',
+  name: '@fastify/redis'
 })
 module.exports.default = fastifyRedis
 module.exports.fastifyRedis = fastifyRedis

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -405,7 +405,7 @@ test('catch .ping() errors', async (t) => {
   await t.assert.rejects(fastify.ready(), new Redis.ReplyError('ping error'))
 })
 
-test("Should propagate SELF_SIGNED_CERT_IN_CHAIN error", async (t) => {
+test('Should propagate SELF_SIGNED_CERT_IN_CHAIN error', async (t) => {
   t.plan(1)
 
   const fastify = Fastify()


### PR DESCRIPTION
Add a more helpful error message when a `"SELF_SIGNED_CERT_IN_CHAIN"` error  code occurs, guiding users on how to resolve the issue.

Adding an error message for this specific case makes sense to me as the error is unrecoverable much like the `"ENOTFOUND"` case.

This error is unrecoverable since ioredis cannot connect unless the TLS
options are changed.

Without this change the error received by the user is the fastify plugin timeout message.
I personally came across this because Heroku Key-Value Store uses self-signed certificates.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
