### PR TITLE
feat: add redis driver identification

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,26 @@
 const fp = require('fastify-plugin')
 const Redis = require('ioredis')
 
+/**
+ * Get the default clientInfoTag for identifying the framework in Redis CLIENT SETINFO.
+ * @returns {string} The client info tag (e.g., "fastify-redis_v7.1.0")
+ */
+function getDefaultClientInfoTag () {
+  try {
+    const version = require('./package.json').version
+    return `fastify-redis_v${version}`
+  } catch {
+    return 'fastify-redis'
+  }
+}
+
 function fastifyRedis (fastify, options, next) {
   const { namespace, url, closeClient = false, ...redisOptions } = options
+
+  // Set default clientInfoTag if not provided and client is not custom
+  if (!options.client && redisOptions.clientInfoTag === undefined) {
+    redisOptions.clientInfoTag = getDefaultClientInfoTag()
+  }
 
   let client = options.client || null
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,12 +33,13 @@ test('fastify.redis should exist', async (t) => {
 })
 
 test('fastify.redis should support url', async (t) => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
 
   const fastifyRedis = proxyquire('..', {
     ioredis: function Redis (path, options) {
       t.assert.deepStrictEqual(path, 'redis://127.0.0.1')
+      t.assert.deepStrictEqual(Object.keys(options).sort(), ['clientInfoTag', 'otherOption'])
       t.assert.deepStrictEqual(options.otherOption, 'foo')
       t.assert.match(options.clientInfoTag, /^fastify-redis_v\d+\.\d+\.\d+$/)
       this.quit = () => {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,13 @@ declare namespace fastifyRedis {
   {
     url?: string;
     namespace?: string;
+    /**
+     * Tag to append to the library name in CLIENT SETINFO (e.g., "ioredis(fastify-redis_v7.1.0)").
+     * This helps identify the framework using the Redis client library.
+     * @link https://redis.io/docs/latest/commands/client-setinfo/
+     * @default "fastify-redis_v{version}" (e.g., "fastify-redis_v7.1.0")
+     */
+    clientInfoTag?: string;
   }) | {
     client: Redis | Cluster;
     namespace?: string;


### PR DESCRIPTION
## Add Redis Driver Identification

This PR adds support for the `clientInfoTag` option, which allows Redis to identify the framework using the client library via the `CLIENT SETINFO` command.

When `@fastify/redis` creates a Redis client internally, it automatically sets `clientInfoTag` to `fastify-redis_v{version}` (e.g., `fastify-redis_v7.1.0`). This helps with debugging and monitoring Redis connections.

As recommended in the [Redis CLIENT INFO documentation](https://redis.io/docs/latest/commands/client-info/), libraries should identify themselves to help with debugging and monitoring.

**Key points:**
- Default tag format: `fastify-redis_v{version}`
- Users can override with a custom `clientInfoTag` option
- Only applies when `@fastify/redis` creates the client (not for custom clients passed via `client` option)
- Non-breaking: Works on ioredis 5.8.0+, silently ignored on older versions

**Example Redis CLIENT INFO output:**
```
lib-name=ioredis(fastify-redis_v7.1.0)
```

## Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)