### PR TITLE
chore: removed types deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,10 +36,7 @@ declare namespace fastifyRedis {
      */
     closeClient?: boolean;
   }
-  /*
-   * @deprecated Use `FastifyRedisPluginOptions` instead
-   */
-  export type FastifyRedisPlugin = FastifyRedisPluginOptions
+
   export const fastifyRedis: FastifyRedisPluginType
   export { fastifyRedis as default }
 }


### PR DESCRIPTION
Proposal:

- Drop `FastifyRedisPlugin` type alias that was marked as `@deprecated` in favour of `FastifyRedisPluginOptions`.


Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274